### PR TITLE
Exposed SDL2 window pointer

### DIFF
--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -30,6 +30,14 @@ namespace Veldrid.Sdl2
         private bool _shouldClose;
         public bool LimitPollRate { get; set; }
         public float PollIntervalInMs { get; set; }
+        
+        public IntPtr SdlWindow 
+        { 
+            get
+            {
+                return _window;
+            }
+        }
 
         // Current input states
         private int _currentMouseX;


### PR DESCRIPTION
Added property to access for SDL2 to allow use of more SDL2 functions(like SDL_SetWindowIcon).

Currently only way to access it is with reflection, which is not very good.
But pointer may be needed for more functions support, like SDL_SetWindowIcon which i mentioned above.