### PR TITLE
Exposed SDL2 window pointer

### DIFF
--- a/src/Veldrid.SDL2/Sdl2Window.cs
+++ b/src/Veldrid.SDL2/Sdl2Window.cs
@@ -31,6 +31,13 @@ namespace Veldrid.Sdl2
         public bool LimitPollRate { get; set; }
         public float PollIntervalInMs { get; set; }
 
+        public IntPtr SdlWindow 
+        { 
+            get
+            {
+                return _window;
+            }
+        }
         // Current input states
         private int _currentMouseX;
         private int _currentMouseY;


### PR DESCRIPTION
Added property to access for SDL2 to allow use of more SDL2 functions(like SDL_SetWindowIcon).