### PR TITLE
Fix marshalling of MTLResourceOptions on .NET 8

### DIFF
--- a/src/Veldrid.MetalBindings/MTLResourceOptions.cs
+++ b/src/Veldrid.MetalBindings/MTLResourceOptions.cs
@@ -1,6 +1,6 @@
 namespace Veldrid.MetalBindings
 {
-    public enum MTLResourceOptions : uint
+    public enum MTLResourceOptions : ulong
     {
         CPUCacheModeDefaultCache = MTLCPUCacheMode.DefaultCache,
         CPUCacheModeWriteCombined = MTLCPUCacheMode.WriteCombined,

--- a/src/Veldrid.MetalBindings/MTLStorageMode.cs
+++ b/src/Veldrid.MetalBindings/MTLStorageMode.cs
@@ -1,6 +1,6 @@
 namespace Veldrid.MetalBindings
 {
-    public enum MTLStorageMode : uint
+    public enum MTLStorageMode : ulong
     {
         Shared = 0,
         Managed = 1,


### PR DESCRIPTION
When running Veldrid + Metal under .NET 8, the app crashes with a trace that looks like the one below.

My investigation into this led to the following conclusion:
- [MTLResourceOptions](https://developer.apple.com/documentation/metal/mtlresourceoptions?language=objc) derives from `NSUInteger`.
- [NSUInteger](https://developer.apple.com/documentation/objectivec/nsuinteger?language=objc) is said to be treated as a 64-bit unsigned integer on 64-bit platforms. 32-bit macOS/iOS doesn't exist anymore, so this is the only one we care about.
- I've looked at Xamarain.iOS' [implementation](https://github.com/xamarin/xamarin-macios/blob/300f6ea92d83556f2e5c31189ae69b7cb8c00cc0/src/Metal/MTLEnums.cs#L693-L718) of this same enum, and they also override ulong.

I believe this is caused by some change in the .NET runtime, but I haven't gone investigating in that aspect.

There may be other calls that fail, but this appears to be working for our app for now.

```
Assertion failed: (false && "Different MTLResourceOptions used for the same heap index, this is not supported"), function IOGPUMetalSuballocatorAllocate, file IOGPUMetalSuballocator.mm, line 191.

=================================================================
	Native Crash Reporting
=================================================================
Got a SIGABRT while executing native code. This usually indicates
a fatal error in the mono runtime or one of the native libraries 
used by your application.
=================================================================

=================================================================
	Native stacktrace:
=================================================================
	0x10395bce0 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x103943708 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x1039f1134 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x10395b4d0 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x212978888 - /usr/lib/system/libsystem_platform.dylib : <redacted>
	0x212a23680 - /usr/lib/system/libsystem_pthread.dylib : pthread_kill
	0x1b0ab1b90 - /usr/lib/system/libsystem_c.dylib : abort
	0x1b0ab0e80 - /usr/lib/system/libsystem_c.dylib : err
	0x21f06d154 - /System/Library/PrivateFrameworks/IOGPU.framework/IOGPU : <redacted>
	0x21f06cfc8 - /System/Library/PrivateFrameworks/IOGPU.framework/IOGPU : <redacted>
	0x242457460 - /System/Library/Extensions/AGXMetalG16P_B0.bundle/AGXMetalG16P_B0 : <redacted>
	0x2424570f4 - /System/Library/Extensions/AGXMetalG16P_B0.bundle/AGXMetalG16P_B0 : <redacted>
	0x10396c534 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x10396ae68 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x10395f874 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x10395cb10 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x10359da18 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : sws_getCachedContext
	0x1aa03d2cc - /System/Library/Frameworks/QuartzCore.framework/QuartzCore : <redacted>
	0x1aa0404b4 - /System/Library/Frameworks/QuartzCore.framework/QuartzCore : <redacted>
	0x1aa03ffc0 - /System/Library/Frameworks/QuartzCore.framework/QuartzCore : <redacted>
	0x1aa0bf290 - /System/Library/Frameworks/QuartzCore.framework/QuartzCore : <redacted>
	0x1aacd77e4 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
	0x1aacd6ed4 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
	0x1aacd6f90 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
	0x1a8a3912c - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
	0x1a8a383a8 - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
	0x1a8a36b5c - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
	0x1a8a35898 - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
	0x1a8a35478 - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : CFRunLoopRunSpecific
	0x1ebfb64f8 - /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices : GSEventRunModal
	0x1aae5962c - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
	0x1aae58c68 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : UIApplicationMain
	0x10490a114 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/Frameworks/SDL2.framework/SDL2 : SDL_UIKitRunApp
	0x10396c508 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x10396ae68 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x10395f874 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x10395d440 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x103921b14 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x1038bd750 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x1038c4cb0 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x103928158 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x1035cd030 - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : xamarin_log
	0x103999ddc - /private/var/containers/Bundle/Application/C8AB0933-C3E3-4FA2-8AE8-91ADC37E3AC6/osu.Framework.Tests.app/osu.Framework.Tests : AppleCryptoNative_X509ImportCertificate
	0x1cb76edcc - /usr/lib/dyld : <redacted>

=================================================================
	Basic Fault Address Reporting
=================================================================
Memory around native instruction pointer (0x1f0169fbc):0x1f0169fac  ff 0f 5f d6 c0 03 5f d6 10 29 80 d2 01 10 00 d4  .._..._..)......
0x1f0169fbc  03 01 00 54 7f 23 03 d5 fd 7b bf a9 fd 03 00 91  ...T.#...{......
0x1f0169fcc  e8 dd ff 97 bf 03 00 91 fd 7b c1 a8 ff 0f 5f d6  .........{...._.
0x1f0169fdc  c0 03 5f d6 7f 23 03 d5 ff c3 00 d1 f4 4f 01 a9  .._..#.......O..

=================================================================
	Managed Stacktrace:
=================================================================
	  at <unknown> <0xffffffff>
	  at Veldrid.MetalBindings.ObjectiveCRuntime:IntPtr_objc_msgSend <0x00066>
	  at Veldrid.MetalBindings.MTLDevice:newBufferWithLengthOptions <0x00044>
	  at Veldrid.MTL.MTLTexture:.ctor <0x00832>
	  at Veldrid.MTL.MTLResourceFactory:CreateTextureCore <0x0002e>
	  at Veldrid.ResourceFactory:CreateTexture <0x0029a>
	  at Veldrid.ResourceFactory:CreateTexture <0x00020>
	  at osu.Framework.Graphics.Veldrid.VeldridStagingTexturePool:Get <0x0016a>
	  at osu.Framework.Graphics.Veldrid.VeldridRenderer:UpdateTexture <0x0007c>
	  at osu.Framework.Graphics.Veldrid.Textures.VeldridTexture:DoUpload <0x00750>
	  at osu.Framework.Graphics.Veldrid.Textures.VeldridTexture:Upload <0x000f4>
	  at osu.Framework.Graphics.Rendering.Renderer:BeginFrame <0x00dd0>
	  at osu.Framework.Graphics.Veldrid.VeldridRenderer:BeginFrame <0x0027c>
	  at osu.Framework.Graphics.Rendering.Renderer:osu.Framework.Graphics.Rendering.IRenderer.BeginFrame <0x00030>
	  at osu.Framework.Platform.GameHost:DrawFrame <0x0041c>
	  at osu.Framework.Threading.GameThread:processFrame <0x00310>
	  at osu.Framework.Threading.GameThread:RunSingleFrame <0x00020>
	  at osu.Framework.Platform.ThreadRunner:RunMainLoop <0x0015c>
	  at osu.Framework.Platform.GameHost:windowUpdate <0x000a6>
	  at osu.Framework.Platform.SDL2Window:RunFrame <0x00180>
	  at osu.Framework.iOS.IOSWindow:runFrame <0x0007a>
	  at osu.Framework.iOS.IOSWindow:runFrame <0x0008a>
	  at <unknown> <0x00000>
	  at <unknown> <0xffffffff>
	  at SDL2.SDL:SDL_UIKitRunApp <0x000ce>
	  at osu.Framework.iOS.GameApplication:Main <0x00212>
	  at osu.Framework.Tests.Application:Main <0x00022>
	  at <Module>:runtime_invoke_direct_void_string[] <0x0007e>
	  at <unknown> <0x00000>
=================================================================
```