### PR TITLE
Fix UpdateBuffer not checking zero size

### DIFF
--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -718,6 +718,10 @@ namespace Veldrid
                 throw new VeldridException(
                     $"The data size given to UpdateBuffer is too large. The given buffer can only hold {buffer.SizeInBytes} total bytes. The requested update would require {bufferOffsetInBytes + sizeInBytes} bytes.");
             }
+            if (sizeInBytes == 0)
+            {
+                return;
+            }
             UpdateBufferCore(buffer, bufferOffsetInBytes, source, sizeInBytes);
         }
 


### PR DESCRIPTION
Calling `GraphicsDevice.UpdateBuffer` with `sizeInBytes == 0` on Vulkan with a recent validation layer (e.g. SDK 1.3.275.0) causes the validation error `VUID-VkBufferCopy-size-01988`. 

The `CommandList.UpdateBuffer` methods have this check already in place so I guess this was a small oversight.