### PR TITLE
Add VK_KHR_portability_enumeration extension and flag

### DIFF
--- a/src/Veldrid/Vk/CommonStrings.cs
+++ b/src/Veldrid/Vk/CommonStrings.cs
@@ -19,5 +19,6 @@
         public static FixedUtf8String main { get; } = "main";
         public static FixedUtf8String VK_KHR_get_physical_device_properties2 { get; } = "VK_KHR_get_physical_device_properties2";
         public static FixedUtf8String VK_KHR_portability_subset { get; } = "VK_KHR_portability_subset";
+        public static FixedUtf8String VK_KHR_portability_enumeration { get; } = "VK_KHR_portability_enumeration";
     }
 }

--- a/src/Veldrid/Vk/VkGraphicsDevice.cs
+++ b/src/Veldrid/Vk/VkGraphicsDevice.cs
@@ -13,6 +13,7 @@ namespace Veldrid.Vk
 {
     internal unsafe class VkGraphicsDevice : GraphicsDevice
     {
+        private const uint VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR = 0x00000001;
         private static readonly FixedUtf8String s_name = "Veldrid-VkGraphicsDevice";
         private static readonly Lazy<bool> s_isSupported = new Lazy<bool>(CheckIsSupported, isThreadSafe: true);
 
@@ -471,6 +472,12 @@ namespace Veldrid.Vk
             if (availableInstanceExtensions.Contains(CommonStrings.VK_KHR_portability_subset))
             {
                 _surfaceExtensions.Add(CommonStrings.VK_KHR_portability_subset);
+            }
+
+            if (availableInstanceExtensions.Contains(CommonStrings.VK_KHR_portability_enumeration))
+            {
+                instanceExtensions.Add(CommonStrings.VK_KHR_portability_enumeration);
+                instanceCI.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
             }
 
             if (availableInstanceExtensions.Contains(CommonStrings.VK_KHR_SURFACE_EXTENSION_NAME))


### PR DESCRIPTION
Currently using Vulkan on MacOS using MoltenVK causes a validation error related to the `VK_KHR_portability_enumeration` extension. The MoltenVK documentation states: 

> Because MoltenVK supports the VK_KHR_portability_subset extension, when using the Vulkan Loader from the Vulkan SDK to run MoltenVK on macOS, the Vulkan Loader will only include MoltenVK VkPhysicalDevices in the list returned by vkEnumeratePhysicalDevices() if the VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR flag is enabled in vkCreateInstance(). See the description of the VK_KHR_portability_enumeration extension in the Vulkan specification for more information about the use of the VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR flag.

This is reproducible in NeoDemo by just switching to the Vulkan backend.