### PR TITLE
Fix Vulkan validation issue with uniform shader memory barriers

### DIFF
--- a/src/Veldrid/Vk/VkCommandList.cs
+++ b/src/Veldrid/Vk/VkCommandList.cs
@@ -760,13 +760,15 @@ namespace Veldrid.Vk
             VkMemoryBarrier barrier;
             barrier.sType = VkStructureType.MemoryBarrier;
             barrier.srcAccessMask = VkAccessFlags.TransferWrite;
-            barrier.dstAccessMask = needToProtectUniform
-                ? VkAccessFlags.VertexAttributeRead | VkAccessFlags.UniformRead
-                : VkAccessFlags.VertexAttributeRead;
+            barrier.dstAccessMask = needToProtectUniform ? VkAccessFlags.UniformRead : VkAccessFlags.VertexAttributeRead;
             barrier.pNext = null;
             vkCmdPipelineBarrier(
                 _cb,
-                VkPipelineStageFlags.Transfer, VkPipelineStageFlags.VertexInput,
+                VkPipelineStageFlags.Transfer, needToProtectUniform ?
+                    VkPipelineStageFlags.VertexShader | VkPipelineStageFlags.ComputeShader |
+                    VkPipelineStageFlags.FragmentShader | VkPipelineStageFlags.GeometryShader |
+                    VkPipelineStageFlags.TessellationControlShader | VkPipelineStageFlags.TessellationEvaluationShader
+                    : VkPipelineStageFlags.VertexInput,
                 VkDependencyFlags.None,
                 1, ref barrier,
                 0, null,


### PR DESCRIPTION
My previous pull request #530 accidentally introduced a Vulkan validation error (sorry about that). This pull request resolves the Vulkan validation error by adjusting the scope of uniform buffer copies to comply with the Vulkan spec. The behaviors of all other buffer copies are unchanged.

Specifically, this changes the destination operation in the memory barrier to cover all shader types instead of reading the vertex input (the Vulkan spec only allows combining `UNIFORM_READ_BIT` with the shader scopes, not with the vertex input scope). It also removes `VertexAttributeRead` as a destination access mask for uniform buffers as that combination is not permitted by the spec. 

Altogether, this treats the copy to a uniform buffer in a separate way from other buffer copies in such a way that ensures correct order of operations when a uniform buffer is updated, while also remaining compliant with the Vulkan spec.